### PR TITLE
Upgrade logback-core to version 1.3.0-alpha10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,12 @@
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
         </dependency>
-    </dependencies>
+      <dependency>
+         <groupId>ch.qos.logback</groupId>
+         <artifactId>logback-core</artifactId>
+         <version>1.3.0-alpha10</version>
+      </dependency>
+   </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades logback-core to 1.3.0-alpha10 to fix vulnerabilities in current version